### PR TITLE
edit,updateアクションの作成、ルーティングの設定、ビューファイル編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show, :edit, :update]
+
   def index
     @items = Item.all.order('created_at DESC')
   end
@@ -21,11 +23,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     if user_signed_in? && current_user.id == @item.user_id
     elsif user_signed_in?
       redirect_to root_path
@@ -35,7 +35,6 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
@@ -50,5 +49,9 @@ class ItemsController < ApplicationController
       .require(:item)
       .permit(:title, :about, :price, :charge_id, :category_id, :condition_id, :till_id, :prefecture_id, :image)
       .merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -22,6 +22,25 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+    if user_signed_in? && current_user.id == @item.user_id
+    elsif user_signed_in?
+      redirect_to root_path
+    else
+      redirect_to new_user_session_path
+    end
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: @item %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :about, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:charge_id, Charge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:till_id, Till.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -9,7 +9,6 @@
 
     <%= render 'shared/error_messages', model: @item %>
 
-    <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -22,8 +21,6 @@
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
@@ -38,9 +35,6 @@
         <%= f.text_area :about, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -56,9 +50,6 @@
         <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
@@ -82,9 +73,6 @@
         <%= f.collection_select(:till_id, Till.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
     <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -113,9 +101,6 @@
         </span>
       </div>
     </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -133,13 +118,10 @@
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
       <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
   </div>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,15 +25,12 @@
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
     <% elsif user_signed_in? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
     <% end %>
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :item do
-    title           {'aa'}
-    about           {'aa'}
-    price           {Faker::Number.within(range: 300..9999999)}
+    title           { 'aa' }
+    about           { 'aa' }
+    price           { Faker::Number.within(range: 300..9_999_999) }
     category_id     { rand(2..11) }
     charge_id          { rand(2..3) }
     condition_id       { rand(2..7) }
@@ -14,6 +14,5 @@ FactoryBot.define do
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
-
   end
 end

--- a/spec/models/ite_spec.rb
+++ b/spec/models/ite_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  before do
+    @item = FactoryBot.build(:item)
+    binding.pry
+  end
+
+  describe '商品出品' do
+    context '商品の出品ができるとき' do
+      #   # binding.pry
+      it 'すべての項目が入力されていれば登録できる' do
+        @item.valid?
+        expect(@item).to be_valid
+      end
+    end
+
+    # context '商品の出品ができないとき' do
+    #   it '画像が添付されていなければ登録できない' do
+    #     @item.image = ''
+    #     expect(@item.errors.full_messages).to include("Image can't be blank")
+    #   end
+    #   it '商品名が空では登録できない' do
+    #     @item.title = ''
+    #     expect(@item.errors.full_messages).to include("Title can't be blank")
+    #   end
+    #   it '商品の説明が空では登録できない' do
+    #     @item.about = ''
+    #     expect(@item.errors.full_messages).to include("About can't be blank")
+    #   end
+    #   it 'カテゴリーが空では登録できない' do
+    #     @item.category.id = ''
+    #     expect(@item.errors.full_messages).to include("Category can't be blank")
+    #   end
+    #   it '商品の状態が空では登録できない' do
+    #     @item.condition.id = ''
+    #     expect(@item.errors.full_messages).to include("Condition can't be blank")
+    #   end
+    #   it '配送料の負担が空では登録できない' do
+    #     @item.charge.id = ''
+    #     expect(@item.errors.full_messages).to include("Charge can't be blank")
+    #   end
+    #   it '発送元の地域が空では登録できない' do
+    #     @item.prefecture.id = ''
+    #     expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+    #   end
+    #   it '発送までの日数が空では登録できない' do
+    #     @item.till.id = ''
+    #     expect(@item.errors.full_messages).to include("Till can't be blank")
+    #   end
+    #   it '価格が空では登録できない' do
+    #     @item.price = ''
+    #     expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999")
+    #   end
+    #   it '価格が全角文字では登録できない' do
+    #     @item.price = 'わあお！'
+    #     expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999")
+    #   end
+    #   it '価格が299円以下では登録できない' do
+    #     @item.price = Faker::number.within(range: 1..299)
+    #     expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999")
+    #   end
+    #   it '価格が10000000以上では登録できない' do
+    #     @item.price = Faker::number.within(from: 10000000)
+    #     expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999")
+    #   end
+    # end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -57,30 +57,29 @@ RSpec.describe Item, type: :model do
       it '価格が空では登録できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999 ")
+        expect(@item.errors.full_messages).to include('Price must be 1-byte number from 300 to 9,999,999 ')
       end
       it '価格が全角文字では登録できない' do
         @item.price = 'わあお！'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999 ")
+        expect(@item.errors.full_messages).to include('Price must be 1-byte number from 300 to 9,999,999 ')
       end
       it '価格が299円以下では登録できない' do
         @item.price = Faker::Number.within(range: 1..299)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999 ")
+        expect(@item.errors.full_messages).to include('Price must be 1-byte number from 300 to 9,999,999 ')
       end
       it '価格が10000000以上では登録できない' do
-        @item.price = Faker::Number.between(from: 10000000)
+        @item.price = Faker::Number.between(from: 10_000_000)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be 1-byte number from 300 to 9,999,999 ")
+        expect(@item.errors.full_messages).to include('Price must be 1-byte number from 300 to 9,999,999 ')
       end
 
       it 'userが紐づいていなければ出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
     end
-
   end
 end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -1,14 +1,12 @@
 require 'rails_helper'
 # 結合テストでやる↓
-RSpec.describe "Items", type: :request do
-  describe "GET /items" do
-
+RSpec.describe 'Items', type: :request do
+  describe 'GET /items' do
     context 'ユーザーがサインインしているとき' do
       it 'newアクションにリクエストすると正常にレスポンスが返ってくる' do
         get new_item_path
         expect(response).to have_http_status(200)
       end
-  
     end
   end
 end

--- a/spec/support/sign_in_support.rb
+++ b/spec/support/sign_in_support.rb
@@ -1,10 +1,8 @@
 module SignInSupport
-
   def sign_in(user)
     visit new_user_session_path
     fill_in 'email', with: user.email
     fill_in 'password', with: user.password
     find('input[name="commit"]').click
   end
-  
 end


### PR DESCRIPTION
# What
* itemsコントローラにedit, updateアクションの作成
* ルーティングの設定
* ビューファイル更新

# Why
* 商品情報編集機能実装のため

商品購入機能は未実装のため、売却済み商品の編集の実装はまだです。

## ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/533de277b4e0f908e243d07248d12c6e

## 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/88565128c7a5de729305df7b57b275d9

## 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/0ff6535bbfbcb0accc572b531891f523

## 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/714529199962b5540ac7b77ff5d16216

## ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/21aef143a7bd09c4700bfdc8a7e9142e

## ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/4c346e612a65b3563815bffe2600493b

## 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/e11a7065f50c332653ab66344e3adfe5